### PR TITLE
Move entries.append()

### DIFF
--- a/peepdf/ext/peepdf/PDFCore.py
+++ b/peepdf/ext/peepdf/PDFCore.py
@@ -7636,13 +7636,13 @@ class PDFParser:
                             return (-1, errorMessage)
                     try:
                         pdfCrossRefEntry = PDFCrossRefEntry(f2, f3, f1)
+                        entries.append(pdfCrossRefEntry)
                     except:
                         errorMessage = 'Error creating PDFCrossRefEntry'
                         if isForceMode:
                             pdfCrossRefSection.addError(errorMessage)
                         else:
                             return (-1, errorMessage)
-                    entries.append(pdfCrossRefEntry)
                 for i in range(int(numSubsections)):
                     firstObject = subsectionIndexes[index]
                     numObjectsInSubsection = subsectionIndexes[index+1]


### PR DESCRIPTION
Fixes: local variable 'pdfCrossRefEntry' referenced before assignment