### PR TITLE
Al 1034 peepdf false positives

### DIFF
--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -378,6 +378,7 @@ class PeePDF(ServiceBase):
                                                                   "deobfuscate code blocks.")
                                             analysis_res.set_heuristic(4)
 
+                                    buff_heuristic_set = False
                                     for buff_idx, buff in enumerate(big_buffs):
                                         error, new_buff = unescape(buff)
                                         if error == 0:
@@ -407,7 +408,9 @@ class PeePDF(ServiceBase):
                                                 f"block{buff_cond}. Here are the first 256 bytes.",
                                                 parent=js_res, body=hexdump(bytes(buff[:256], "utf-8")),
                                                 body_format=BODY_FORMAT.MEMORY_DUMP)
-                                            buff_res.set_heuristic(2)
+                                            if not buff_heuristic_set:
+                                                js_res.set_heuristic(2)
+                                                buff_heuristic_set = True
 
                                 for sc_idx, sc in enumerate(set(unescaped_bytes)):
                                     try:

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -216,8 +216,8 @@ class PeePDF(ServiceBase):
 
                 if stats_dict['Encryption Algorithms']:
                     temp = []
-                    for algorithmInfo in stats_dict['Encryption Algorithms']:
-                        temp.append(f"{algorithmInfo[0]} {str(algorithmInfo[1])} bits")
+                    for algorithm_info in stats_dict['Encryption Algorithms']:
+                        temp.append(f"{algorithm_info[0]} {str(algorithm_info[1])} bits")
                     json_body["encryption_algorithms"] = temp
 
                 json_body.update(dict(
@@ -270,61 +270,55 @@ class PeePDF(ServiceBase):
                     events = stats_version['Events']
                     vulns = stats_version['Vulns']
                     elements = stats_version['Elements']
-                    is_suspicious = False
                     if events is not None or actions is not None or vulns is not None or elements is not None:
                         res_suspicious = ResultSection('Suspicious elements', parent=res_version)
+                        res_suspicious.set_heuristic(8)
                         if events is not None:
                             for event in events:
                                 res_suspicious.add_line(f"{event}: {self.list_first_x(events[event])}")
-                            is_suspicious = True
                         if actions is not None:
                             for action in actions:
                                 res_suspicious.add_line(f"{action}: {self.list_first_x(actions[action])}")
-                            is_suspicious = True
                         if vulns is not None:
                             for vuln in vulns:
                                 if vuln in vulnsDict:
                                     temp = [vuln, ' (']
-                                    for vulnCVE in vulnsDict[vuln]:
+                                    for vuln_cve in vulnsDict[vuln]:
                                         if len(temp) != 2:
                                             temp.append(',')
-                                            vulnCVE = "".join(vulnCVE) if isinstance(vulnCVE, list) else vulnCVE
-                                            temp.append(vulnCVE)
-                                            cve_found = re.search("CVE-[0-9]{4}-[0-9]{4}", vulnCVE)
+                                            vuln_cve = "".join(vuln_cve) if isinstance(vuln_cve, list) else vuln_cve
+                                            temp.append(vuln_cve)
+                                            cve_found = re.search("CVE-[0-9]{4}-[0-9]{4}", vuln_cve)
                                             if cve_found:
-                                                res_suspicious.add_tag('attribution.exploit',
-                                                                       vulnCVE[cve_found.start():cve_found.end()])
-                                                res_suspicious.add_tag('file.behavior',
-                                                                       vulnCVE[cve_found.start():cve_found.end()])
+                                                vuln_name = vuln_cve[cve_found.start():cve_found.end()]
+                                                res_suspicious.add_tag('attribution.exploit', vuln_name)
+                                                res_suspicious.add_tag('file.behavior', vuln_name)
+                                                res_suspicious.heuristic.add_signature_id(vuln_name, score=500)
                                     temp.append('): ')
                                     temp.append(str(vulns[vuln]))
                                     res_suspicious.add_line(temp)
                                 else:
                                     res_suspicious.add_line(f"{vuln}: {str(vulns[vuln])}")
-                                is_suspicious = True
                         if elements is not None:
                             for element in elements:
                                 if element in vulnsDict:
                                     temp = [element, ' (']
-                                    for vulnCVE in vulnsDict[element]:
+                                    for vuln_cve in vulnsDict[element]:
                                         if len(temp) != 2:
                                             temp.append(',')
-                                        vulnCVE = "".join(vulnCVE) if isinstance(vulnCVE, list) else vulnCVE
-                                        temp.append(vulnCVE)
-                                        cve_found = re.search("CVE-[0-9]{4}-[0-9]{4}", vulnCVE)
+                                        vuln_cve = "".join(vuln_cve) if isinstance(vuln_cve, list) else vuln_cve
+                                        temp.append(vuln_cve)
+                                        cve_found = re.search("CVE-[0-9]{4}-[0-9]{4}", vuln_cve)
                                         if cve_found:
-                                            res_suspicious.add_tag('attribution.exploit',
-                                                                   vulnCVE[cve_found.start():cve_found.end()])
-                                            res_suspicious.add_tag('file.behavior',
-                                                                   vulnCVE[cve_found.start():cve_found.end()])
+                                            vuln_name = vuln_cve[cve_found.start():cve_found.end()]
+                                            res_suspicious.add_tag('attribution.exploit', vuln_name)
+                                            res_suspicious.add_tag('file.behavior', vuln_name)
+                                            res_suspicious.heuristic.add_signature_id(vuln_name, score=500)
                                     temp.append('): ')
                                     temp.append(str(elements[element]))
                                     res_suspicious.add_line(temp)
-                                    is_suspicious = True
                                 else:
                                     res_suspicious.add_line(f"\t\t{element}: {str(elements[element])}")
-                                    is_suspicious = True
-                    res_suspicious.set_heuristic(8) if is_suspicious else None
 
                     urls = stats_version['URLs']
                     if urls is not None:

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -359,7 +359,6 @@ class PeePDF(ServiceBase):
                                     has_results = True
                                     js_cmt = "Suspiciously malicious "
                                     cur_res.add_tag('file.behavior', "Suspicious JavaScript in PDF")
-                                    sub_res.set_heuristic(7)
                                 js_res = ResultSection(f"{js_cmt}JavaScript Code (block: {js_idx})", parent=sub_res)
 
                                 if has_js_results:
@@ -383,7 +382,7 @@ class PeePDF(ServiceBase):
                                                                   "function. It may be legitimate but it is definitely "
                                                                   "suspicious since malware often use this to "
                                                                   "deobfuscate code blocks.")
-                                            analysis_res.set_heuristic(3)
+                                            analysis_res.set_heuristic(4)
 
                                     for buff_idx, buff in enumerate(big_buffs):
                                         error, new_buff = unescape(buff)

--- a/pipelines/azure-build.yaml
+++ b/pipelines/azure-build.yaml
@@ -26,5 +26,5 @@ stages:
         export TAG=${BUILD_SOURCEBRANCH#"refs/tags/v"}
         if [[ "$TAG" == *stable* ]]; then export BUILD_TYPE=stable; else export BUILD_TYPE=latest; fi
         docker build --build-arg version=$TAG -t cccs/assemblyline-service-peepdf:$TAG -t cccs/assemblyline-service-peepdf:$BUILD_TYPE .
-        docker push cccs/assemblyline-service-peepdf
+        docker push cccs/assemblyline-service-peepdf --all-tags
       displayName: Deploy to Docker Hub

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -29,7 +29,7 @@ heuristics:
   - heur_id: 2
     filetype: document/pdf
     name: Large Buffers
-    score: 500
+    score: 100
     description: >-
       A buffer was found in the JavaScript code.
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -67,7 +67,7 @@ heuristics:
   - heur_id: 8
     filetype: document/pdf
     name: Suspicious JavaScript Elements
-    score: 100
+    score: 0
     description: >-
       Suspicious JavaScript elements have been found within the file.
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -64,14 +64,6 @@ heuristics:
       If looking for JavaScript shellcode fails, the JavaScript is an
       unknown unescaped buffer.
 
-  - heur_id: 7
-    filetype: document/pdf
-    name: Suspicious JavaScript Code
-    score: 50
-    description: >-
-      If the file contents of the PDF has either "eval" or "unescape" or
-      large buffer variables were found.
-
   - heur_id: 8
     filetype: document/pdf
     name: Suspicious JavaScript Elements


### PR DESCRIPTION
Fixing heuristics 2, 4, 7 and 8:
- heuristic 2 large buffers was set for each buffer for 500 score each, now set once for 100 score to avoid false positives
- heuristic 4 was being set as heuristic 3
- heuristic 7 was only raised when one of heuristics 2, 3, or 4 were and added no additional info and is removed
- heuristic 8 was mostly redundant with Pdfid results except for CVE discoveries which were underscored. It now has no default score and CVEs are set as signatures with a score of 500

Also several style changes, mostly replacing index variables with enumerate and file handling with "with" blocks