### PR TITLE
Combine javascript sections

### DIFF
--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -26,6 +26,16 @@ def validate_non_humanreadable_buff(data, buff_min_size=256, whitespace_ratio=0.
 
     return False
 
+def check_for_function(function: str, data: str) -> bool:
+    """ Checks for a function in javascript code
+
+    function: the name of the function
+    data: the javascript code
+
+    returns: Whether the code contains the function
+    """
+    return re.search(f'[^a-zA-Z]{function}[^a-zA-Z]', data)
+
 
 # noinspection PyGlobalUndefined
 class PeePDF(ServiceBase):
@@ -168,39 +178,6 @@ class PeePDF(ServiceBase):
         return out
 
     @staticmethod
-    def check_dangerous_func(data):
-        """ Check for the functions eval and unescape """
-        has_eval = False
-        has_unescape = False
-        # eval
-        temp_eval = data.split("eval")
-        if len(temp_eval) > 1:
-            for idx, i in enumerate(temp_eval[:-1]):
-                if (97 <= ord(i[-1]) <= 122) or (65 <= ord(i[-1]) <= 90):
-                    continue
-                if (97 <= ord(temp_eval[idx][0]) <= 122) or \
-                        (65 <= ord(temp_eval[idx][0]) <= 90):
-                    continue
-
-                has_eval = True
-                break
-
-        # unescape
-        temp_unesc = data.split("unescape")
-        if len(temp_unesc) > 1:
-            for idx, i in enumerate(temp_unesc[:-1]):
-                if (97 <= ord(i[-1]) <= 122) or (65 <= ord(i[-1]) <= 90):
-                    continue
-                if (97 <= ord(temp_unesc[idx][0]) <= 122) or \
-                        (65 <= ord(temp_unesc[idx][0]) <= 90):
-                    continue
-
-                has_unescape = True
-                break
-
-        return has_eval, has_unescape
-
-    @staticmethod
     def list_first_x(mylist, size=20):
         """ Truncate list for display """
         add_reminder = len(mylist) > size
@@ -216,7 +193,8 @@ class PeePDF(ServiceBase):
         buffers = False
 
         # Check for Eval and Unescape
-        has_eval, has_unescape = self.check_dangerous_func(js_code)
+        has_eval = check_for_function("eval", js_code)
+        has_unescape = check_for_function("unescape", js_code)
         if has_eval:
             eval_res = ResultSection("[Suspicious Function] eval()", parent=js_res)
 

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -49,9 +49,10 @@ class PeePDF(ServiceBase):
         super().__init__(config)
         self.max_pdf_size = self.config.get('max_pdf_size', 3000000)
 
-    def extract(self, data: bytes, filename: str, request,
-            description="Dumped from {os.path.basename(request.file_path)}"):
+    def extract(self, data: bytes, filename: str, request, description: str=''):
         """ Extract data as filename in the current working directory and add to request """
+        if not description:
+            description = f"Dumped from {os.path.basename(request.file_path)}"
         file_path = os.path.join(self.working_directory, filename)
         with open(file_path, 'wb') as f:
             f.write(data)
@@ -383,7 +384,7 @@ class PeePDF(ServiceBase):
                 'binary': stats_dict['Binary'],
                 'linearized': stats_dict['Linearized'],
                 'encrypted': stats_dict['Encrypted'],
-                'Encryption Algorithms': [f"{algorithm_info[0]} {str(algorithm_info[1])} bits"
+                'encryption_algorithms': [f"{algorithm_info[0]} {str(algorithm_info[1])} bits"
                     for algorithm_info in stats_dict['Encryption Algorithms']],
                 'updates': stats_dict['Updates'],
                 'objects': stats_dict['Objects'],
@@ -391,6 +392,8 @@ class PeePDF(ServiceBase):
                 'comments': stats_dict['Comments'],
                 'errors': ', '.join(stats_dict['Errors'] if stats_dict['Errors'] else 'None')
         }
+        if not json_body['encryption_algorithms']:
+            del json_body['encryption_algorithms']
 
         res = ResultSection("PDF File Information", body_format=BODY_FORMAT.KEY_VALUE,
                             body=json.dumps(json_body), parent=request.result)

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -30,7 +30,7 @@ class PeePDF(ServiceBase):
     CVE_FALSE_POSITIVES = ["CVE-2009-0658", "CVE-2010-0188"]
 
     def __init__(self, config=None):
-        super(PeePDF, self).__init__(config)
+        super().__init__(config)
         self.max_pdf_size = self.config.get('max_pdf_size', 3000000)
 
     # noinspection PyUnusedLocal,PyMethodMayBeStatic
@@ -330,90 +330,85 @@ class PeePDF(ServiceBase):
                             res_url.add_line(f"\t\t{url}")
                             res_url.set_heuristic(9)
 
+                    javascript_res_added = False
+                    buff_heuristic_set = False
+                    javascript_res = ResultSection("Javascript blocks found")
                     for obj in stats_version['Objects'][1]:
                         cur_obj = pdf_file.getObject(obj, version)
 
                         if cur_obj.containsJScode:
-                            cur_res = ResultSection(f"Object [{obj} {version}] contains {len(cur_obj.JSCode)} "
-                                                    f"block of JavaScript")
-                            has_results = False
-
+                            javascript_res.add_line(f"Object [{obj} {version}] contains {len(cur_obj.JSCode)} "
+                                                    f"block(s) of JavaScript")
                             for js_idx, js in enumerate(cur_obj.JSCode):
-                                sub_res = ResultSection('Block of JavaScript', parent=cur_res)
-                                js_code, unescaped_bytes, _, _, _ = analyseJS(js)
+                                js_res = ResultSection(f"JavaScript Code (block: {js_idx})", parent=javascript_res)
 
+                                js_code, unescaped_bytes, _, _, _ = analyseJS(js)
                                 js_dump += js_code
 
-                                # Malicious characteristics
-                                big_buffs = self.get_big_buffs("".join(js_code))
+                                # Check for Eval and Unescape
                                 has_eval, has_unescape = self.check_dangerous_func("".join(js_code))
-                                has_js_results = has_eval or has_unescape or len(big_buffs) > 0
+                                if has_eval:
+                                    eval_res = ResultSection("[Suspicious Function] eval()", parent=js_res)
 
+                                    eval_res.add_line("This JavaScript block uses eval() function "
+                                                              "which is often used to launch deobfuscated "
+                                                              "JavaScript code.")
+                                    eval_res.set_heuristic(3)
+                                if has_unescape:
+                                    unescape_res = ResultSection("[Suspicious Function] unescape()", parent=js_res)
+                                    unescape.add_line("This JavaScript block uses unescape() "
+                                                              "function. It may be legitimate but it is definitely "
+                                                              "suspicious since malware often use this to "
+                                                              "deobfuscate code blocks.")
+                                    unescape.set_heuristic(4)
 
-                                js_cmt = ""
-                                if has_js_results:
-                                    has_results = True
-                                    js_cmt = "Suspiciously malicious "
-                                    cur_res.add_tag('file.behavior', "Suspicious JavaScript in PDF")
-                                js_res = ResultSection(f"{js_cmt}JavaScript Code (block: {js_idx})", parent=sub_res)
+                                # Large Buffers
+                                big_buffs = self.get_big_buffs("".join(js_code))
+                                for buff_idx, buff in enumerate(big_buffs):
+                                    error, new_buff = unescape(buff)
+                                    if error == 0:
+                                        buff = new_buff
 
-                                if has_js_results:
+                                    if buff not in unescaped_bytes:
+                                        temp_path_name = None
+                                        if ";base64," in buff[:100] and "data:" in buff[:100]:
+                                            temp_path_name = f"obj{obj}_unb64_{buff_idx}.buff"
+                                            try:
+                                                buff = b64decode(buff.split(";base64,")[1].strip())
+                                                temp_path = os.path.join(self.working_directory, temp_path_name)
+                                                with open(temp_path, "wb") as f:
+                                                    f.write(buff)
+                                                f_list.append(temp_path)
+                                            except Exception:
+                                                self.log.error("Found 'data:;base64, ' buffer "
+                                                               "but failed to base64 decode.")
+                                                temp_path_name = None
+
+                                        if temp_path_name is not None:
+                                            buff_cond = f" and was resubmitted as {temp_path_name}"
+                                        else:
+                                            buff_cond = ""
+                                        buff_res = ResultSection(
+                                            f"A {len(buff)} bytes buffer was found in the JavaScript "
+                                            f"block{buff_cond}. Here are the first 256 bytes.",
+                                            parent=js_res, body=hexdump(bytes(buff[:256], "utf-8")),
+                                            body_format=BODY_FORMAT.MEMORY_DUMP)
+                                        if not buff_heuristic_set:
+                                            javascript_res.set_heuristic(2)
+                                            buff_heuristic_set = True
+
+                                # Extract javascript block
+                                if has_eval or has_unescape or len(big_buffs > 0):
+                                    js_res.add_tag('file.behaviour', "Suspicious Javascript in PDF")
                                     temp_js_outname = f"object{obj}-{version}_{js_idx}.js"
                                     temp_js_path = os.path.join(self.working_directory, temp_js_outname)
                                     temp_js_bin = "".join(js_code).encode("utf-8")
                                     with open(temp_js_path, "wb") as f:
                                         f.write(temp_js_bin)
                                     f_list.append(temp_js_path)
-
                                     js_res.add_line(f"The JavaScript block was saved as {temp_js_outname}")
-                                    if has_eval or has_unescape:
-                                        analysis_res = ResultSection("[Suspicious Functions]", parent=js_res)
-                                        if has_eval:
-                                            analysis_res.add_line("eval: This JavaScript block uses eval() function "
-                                                                  "which is often used to launch deobfuscated "
-                                                                  "JavaScript code.")
-                                            analysis_res.set_heuristic(3)
-                                        if has_unescape:
-                                            analysis_res.add_line("unescape: This JavaScript block uses unescape() "
-                                                                  "function. It may be legitimate but it is definitely "
-                                                                  "suspicious since malware often use this to "
-                                                                  "deobfuscate code blocks.")
-                                            analysis_res.set_heuristic(4)
 
-                                    buff_heuristic_set = False
-                                    for buff_idx, buff in enumerate(big_buffs):
-                                        error, new_buff = unescape(buff)
-                                        if error == 0:
-                                            buff = new_buff
-
-                                        if buff not in unescaped_bytes:
-                                            temp_path_name = None
-                                            if ";base64," in buff[:100] and "data:" in buff[:100]:
-                                                temp_path_name = f"obj{obj}_unb64_{buff_idx}.buff"
-                                                try:
-                                                    buff = b64decode(buff.split(";base64,")[1].strip())
-                                                    temp_path = os.path.join(self.working_directory, temp_path_name)
-                                                    with open(temp_path, "wb") as f:
-                                                        f.write(buff)
-                                                    f_list.append(temp_path)
-                                                except Exception:
-                                                    self.log.error("Found 'data:;base64, ' buffer "
-                                                                   "but failed to base64 decode.")
-                                                    temp_path_name = None
-
-                                            if temp_path_name is not None:
-                                                buff_cond = f" and was resubmitted as {temp_path_name}"
-                                            else:
-                                                buff_cond = ""
-                                            buff_res = ResultSection(
-                                                f"A {len(buff)} bytes buffer was found in the JavaScript "
-                                                f"block{buff_cond}. Here are the first 256 bytes.",
-                                                parent=js_res, body=hexdump(bytes(buff[:256], "utf-8")),
-                                                body_format=BODY_FORMAT.MEMORY_DUMP)
-                                            if not buff_heuristic_set:
-                                                js_res.set_heuristic(2)
-                                                buff_heuristic_set = True
-
+                                # Handle unescaped buffers
                                 for sc_idx, sc in enumerate(set(unescaped_bytes)):
                                     try:
                                         sc = sc.decode("hex")
@@ -433,12 +428,13 @@ class PeePDF(ServiceBase):
                                         f.write(sc)
                                     f_list.append(temp_path)
 
-                                    cur_res.add_tag('file.behavior', "Unescaped JavaScript Buffer")
+                                    js_res.add_tag('file.behavior', "Unescaped JavaScript Buffer")
                                     shell_res.set_heuristic(6)
-                                    has_results = True
 
-                            if has_results:
-                                res_list.append(cur_res)
+                                if js_res.subsections:
+                                    javascript_res.add_subsection(js_res)
+                                    if not javascript_res_added:
+                                        res_list.append(javascript_res)
 
                         elif cur_obj.type == "stream":
                             if cur_obj.isEncodedStream and cur_obj.filter is not None:


### PR DESCRIPTION
Minor change to large buffer section turned into large refactor:
- Large buffers heuristic reported once across javascript objects, instead of once per object
- Error checking code moved from peepdf_analysis() to execute() to reduce nesting
- Logging of errors added
- peepdf_analysis broken up with 3 subfunctions for version information, javascript, and streams respectively
- Docstrings added where missing
- embedded xdp detection fixed
- code simplified in several places