### PR TITLE
Improve check_for_function regex

### DIFF
--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -40,7 +40,7 @@ def check_for_function(function: str, data: str) -> bool:
 
     returns: Whether the code contains the function
     """
-    return bool(re.search(f'[^a-zA-Z]{function}[^a-zA-Z]', data))
+    return bool(re.search(rf'\b{function}\s*\(', data))
 
 # noinspection PyGlobalUndefined
 class PeePDF(ServiceBase):

--- a/tests/test_peepdf_static.py
+++ b/tests/test_peepdf_static.py
@@ -1,0 +1,12 @@
+import pytest
+
+from peepdf.peepdf import check_for_function
+
+@pytest.mark.parametrize(("data", "result"), [
+    ("evalua", False),
+    ("eval()", True),
+    ("eval (", True),
+    ("(eval)", False),
+])
+def test_check_for_function_eval(data, result):
+    assert check_for_function("eval", data) == result


### PR DESCRIPTION
- \b instead of [^a-zA-Z] to allow matching start of input and reject `_`
- require open paren to indicate the function being called.